### PR TITLE
Feature/repl returning res stdout stderr

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,6 +1,11 @@
 body {
-    max-width: 800px;
+    max-width: 860px;
     margin: 0 auto;
+    font-size: 1rem;
+    font-family: sans-serif;
+    line-height: 1.4;
+    color: #222;
+    padding: 20px;
 }
 
 /* modifying monokai */
@@ -25,9 +30,11 @@ body {
 }
 
 .eval-result pre:not(:empty)::before {
-    margin-left: -30px;
-    width: 30px;
-    display: inline-block;
+    background-color: white;
+    display: block;
+}
+pre {
+    overflow: auto;
 }
 
 .eval-result pre:empty::before {
@@ -35,13 +42,23 @@ body {
     display: none;
 }
 .res::before {
-    content: " =>";
+    content: "result";
 }
 
 .out::before {
-    content: "out";
+    content: "output";
 }
 
 .err::before {
-    content: "err";
+    content: "error";
+}
+
+code {
+    font-family: 'Inconsolata', monospace;
+    padding: 0 5px;
+    background-color: #EEE;
+}
+
+.code-container {
+    margin-top: 20px;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -2,7 +2,7 @@ body {
     max-width: 860px;
     margin: 0 auto;
     /* 1rem ? */
-    font-size: 14px; 
+    font-size: 16px;
     font-family: sans-serif;
     /* line-height: 1.4; */
     color: #222;
@@ -27,7 +27,7 @@ body {
 
 .eval-result pre:not(:empty)::before {
     color: #666;
-    font-size: 0.8em;
+    font-size: 0.7em;
     display: block;
     padding-top: 5px;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -1,40 +1,49 @@
 body {
     max-width: 860px;
     margin: 0 auto;
-    font-size: 1rem;
+    /* 1rem ? */
+    font-size: 14px; 
     font-family: sans-serif;
-    line-height: 1.4;
+    /* line-height: 1.4; */
     color: #222;
     padding: 20px;
 }
 
 /* modifying monokai */
 .CodeMirror-matchingbracket {
-    /* outline:1px solid grey; */
     text-decoration: none !important;
     background: #666;
-    /* color:black !important; */
 }
 .CodeMirror {
     height: auto;
 }
 
-.res, pre.example {
-    background-color: #CCC;
-}
 .out {
-    background-color: rgba(0, 0, 255, 0.2);
+    color: #33F;
 }
 .err {
-    background-color: rgba(255, 0, 0, 0.2);
+    color: #F33;
 }
 
 .eval-result pre:not(:empty)::before {
-    background-color: white;
+    color: #666;
+    font-size: 0.8em;
     display: block;
+    padding-top: 5px;
 }
-pre {
+.code-container {
+    margin-top: 20px;
+    background-color: #EEE;
+}
+.eval-result {
+    margin-bottom: 20px;
+    background-color: #EEE;
+    padding-bottom: 10px;
+}
+.eval-result pre {
     overflow: auto;
+    margin: 0px; /* default is 14px !! */
+    padding-left: 10px;
 }
 
 .eval-result pre:empty::before {
@@ -57,8 +66,4 @@ code {
     font-family: 'Inconsolata', monospace;
     padding: 0 5px;
     background-color: #EEE;
-}
-
-.code-container {
-    margin-top: 20px;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -23,3 +23,25 @@ body {
 .err {
     background-color: rgba(255, 0, 0, 0.2);
 }
+
+.eval-result pre:not(:empty)::before {
+    margin-left: -30px;
+    width: 30px;
+    display: inline-block;
+}
+
+.eval-result pre:empty::before {
+    content: "";
+    display: none;
+}
+.res::before {
+    content: " =>";
+}
+
+.out::before {
+    content: "out";
+}
+
+.err::before {
+    content: "err";
+}

--- a/dev.org
+++ b/dev.org
@@ -137,20 +137,21 @@ This function is called by `org-babel-execute-src-block'"
 		     ;; #<unspecifed> etc cannot be read by emacs
 		     ;; also, out is a result of split-string, so we get the car
 		     (blah (print (car out)))
-		     (out (print (s-replace "#" "" (car out))))
+		     ;; fixing the #<unspecified> not being readable by emacs-lisp
+		     (out (print (s-replace "#<" "<" (car out))))
 		     (parsed (read out))
-		     (parsed (mapcar (lambda (el)
-				       (xml-escape-string
-					(if (symbolp el)
-					    (symbol-name el)
-					  el))
-				       )
-				     parsed)))
+		     (parsed2 (mapcar (lambda (el)
+					(xml-escape-string
+					 ;; note: %S print string quoted
+					 ;; %s removes the ".. but it's more annyoing to have it
+					 (format "%s" el)
+					 ))
+				      parsed)))
 		(concat
 		 "<div class='eval-result'>\n"
-		 (format "<pre class='res'>%s</pre>\n" (car parsed))
-		 (format "<pre class='out'>%s</pre>\n" (cadr parsed))
-		 (format "<pre class='err'>%s</pre>\n" (caddr parsed))
+		 (format "<pre class='res'>%s</pre>\n" (xml-escape-string (format "%S" (car parsed))))
+		 (format "<pre class='out'>%s</pre>\n" (cadr parsed2))
+		 (format "<pre class='err'>%s</pre>\n" (caddr parsed2))
 		 "</div>"
 		 )
 		;; (print out)

--- a/dev.org
+++ b/dev.org
@@ -99,7 +99,7 @@ Note: the input text has already the code wrapped around some html tages which w
 	 (formatted (format "<div class='code-container'>
 <textarea class='code'>%s</textarea>
 <button class='eval'>eval</button>
-</div>" code)))
+</div>\n" code)))
     formatted))
 
 ;; add-to-list doesn't add if it's already there! phew!
@@ -118,44 +118,62 @@ Note: the input text has already the code wrapped around some html tages which w
 ** org-babel-execute:scheme
    Redefining =org-babel-execute:scheme= cause it uses geiser.. ugh!
    #+BEGIN_SRC emacs-lisp :results silent
+(defun s7-playground/parse-repl-output (output)
+  "The s7-playgroudn repl returns a list upon input
+result stdout stderr.
+This function parses this string output and returns
+an emacs-lisp list"
+  (print "here..")
+  (print output)
+  ;; fixing the #<unspecified> not being readable by emacs-lisp
+  (let ((parsed (read (s-replace "#<" "<" output))))
+    (list
+     ;; result
+     ;; %S cause we want string to be quoted
+     (format "%S" (car parsed))
+     ;; in the stdout and stderr we don't need this info
+     (format "%s" (cadr parsed))
+     (format "%s" (caddr parsed))
+     )))
+
+(defun s7-playground/org-babel-output (repl-output-parsed &optional type)
+  "Type could be \"value\" \"output\" or \"error\".
+This is coming from :s7-results header args, in the same fashing as :results
+In any other case it will return 3 pre blocks with the res out and err classes."
+  (print repl-output-parsed)
+  (print "cond?")
+  (print type)
+  (cond ((string= type "value") (format "%s" (car repl-output-parsed)))
+	((string= type "output") (format "%s" (cadr repl-output-parsed)))
+	((string= type "error") (format "%s" (caddr repl-output-parsed)))
+	(t (progn
+	     (print "heree??")
+	     (concat
+	      "<div class='eval-result'>\n"
+	      (format "<pre class='res'>%s</pre>\n" (xml-escape-string (car repl-output-parsed)))
+	      (format "<pre class='out'>%s</pre>\n" (xml-escape-string (cadr repl-output-parsed)))
+	      (format "<pre class='err'>%s</pre>\n" (xml-escape-string (caddr repl-output-parsed)))
+	      "</div>"
+	      )))))
+
 (defun org-babel-execute:scheme (body params)
   "Execute a block of Scheme code with org-babel.
 This function is called by `org-babel-execute-src-block'"
-
+  (print params)
+  (print (cdr (assq :s7-results params)))
   (save-excursion
     (let* ((result-type (cdr (assq :result-type params)))
 	   (session "*scheme*")
 	   (full-body (org-babel-expand-body:scheme body params))
-	   (comint-use-prompt-regexp nil)
 	   (result
 	    (progn
-	      (print comint-prompt-regexp)
-	      (let* ((out (print (org-babel-comint-with-output
-				     ("*scheme*" "\n> " )
-				   (scheme-send-string (format "(begin %s\n)" body))
-				   (accept-process-output (get-buffer-process (current-buffer))))))
-		     ;; #<unspecifed> etc cannot be read by emacs
-		     ;; also, out is a result of split-string, so we get the car
-		     (blah (print (car out)))
-		     ;; fixing the #<unspecified> not being readable by emacs-lisp
-		     (out (print (s-replace "#<" "<" (car out))))
-		     (parsed (read out))
-		     (parsed2 (mapcar (lambda (el)
-					(xml-escape-string
-					 ;; note: %S print string quoted
-					 ;; %s removes the ".. but it's more annyoing to have it
-					 (format "%s" el)
-					 ))
-				      parsed)))
-		(concat
-		 "<div class='eval-result'>\n"
-		 (format "<pre class='res'>%s</pre>\n" (xml-escape-string (format "%S" (car parsed))))
-		 (format "<pre class='out'>%s</pre>\n" (cadr parsed2))
-		 (format "<pre class='err'>%s</pre>\n" (caddr parsed2))
-		 "</div>"
-		 )
-		;; (print out)
-		;;(s-trim (mapconcat #'identity out "\n"))
+	      (let* ((out (org-babel-comint-with-output
+			      ("*scheme*" "\n> " )
+			    (scheme-send-string (format "(begin %s\n)" body))
+			    (accept-process-output (get-buffer-process (current-buffer)))))
+		     ;; out is a result of split-string, so we get the car
+		     (parsed (s7-playground/parse-repl-output (car out))))
+		(s7-playground/org-babel-output parsed (cdr (assq :s7-results params)))
 		))))
       result)))
    #+END_SRC

--- a/dev.org
+++ b/dev.org
@@ -8,11 +8,37 @@ source ./emsdk_env.sh
 emcc -v
    #+END_SRC
 
+** Building the special repl
+   #+BEGIN_SRC sh
+meson setup buildc
+   #+END_SRC
+
+   Building & launching
+   #+BEGIN_SRC sh
+ninja -C buildc
+   #+END_SRC
+
+   #+BEGIN_SRC sh
+./buildc/repl
+   #+END_SRC
+
+   #+BEGIN_SRC emacs-lisp :results silent
+(run-scheme (concat "buildc/repl"))
+   #+END_SRC
+
+   #+BEGIN_SRC scheme
+(begin
+  (display "here 1")
+  (display "here 2")
+  (format #t "aaa")
+  (+ 1 2 3))
+   #+END_SRC
+
 ** Building
    Note: =emcc= has to be in the path for the following to work
 
    Setting up project
-   #+BEGIN_SRC src
+   #+BEGIN_SRC sh
 meson setup build --cross-file wasm.ini
    #+END_SRC
 

--- a/dev.org
+++ b/dev.org
@@ -74,3 +74,88 @@ git clone https://github.com/shaunlebron/parinfer-codemirror.git ~/dev/github/pa
 cd ~/dev/github/parinfer-codemirror
 npm install
   #+END_SRC
+* emacs-lisp etc
+  The following
+
+  #+BEGIN_SRC emacs-lisp :results silent
+;; replace with an s7 repl that handles multi line input properly
+(run-scheme (concat "buildc/repl"))
+  #+END_SRC
+
+  #+BEGIN_SRC sh
+source ~/dev/github/emsdk/emsdk_env.sh
+emrun --serve_after_close index.html
+  #+END_SRC
+** org-export-filter-src-block-functions
+   https://orgmode.org/manual/Advanced-Export-Configuration.html
+   Making the src blocks a text input + an eval button
+
+   #+BEGIN_SRC emacs-lisp :results silent
+(defun s7-playground/src-block (text backend info)
+  "Exports a (scheme) src-block as a textarea coupled with an 'eval' button.
+This later gets converted to a codemirror editor.
+Note: the input text has already the code wrapped around some html tages which we strip ourselves"
+  (let* ((code (s-trim (replace-regexp-in-string "<[^>]*>" "" text)))
+	 (formatted (format "<div class='code-container'>
+<textarea class='code'>%s</textarea>
+<button class='eval'>eval</button>
+</div>" code)))
+    formatted))
+
+;; add-to-list doesn't add if it's already there! phew!
+(add-to-list 'org-export-filter-src-block-functions
+	      's7-playground/src-block)
+   #+END_SRC
+
+
+*** Other notes
+    #+BEGIN_QUOTE
+   
+    Oh wait! Just found org-babel-map-src-blocks and the two hooks org-export-before-{processing,parsing}-hook. That's probably what I'm going to do. – purple_arrows Sep 25 '18 at 22:14
+
+    #+END_QUOTE
+
+** org-babel-execute:scheme
+   Redefining =org-babel-execute:scheme= cause it uses geiser.. ugh!
+   #+BEGIN_SRC emacs-lisp :results silent
+(defun org-babel-execute:scheme (body params)
+  "Execute a block of Scheme code with org-babel.
+This function is called by `org-babel-execute-src-block'"
+
+  (save-excursion
+    (let* ((result-type (cdr (assq :result-type params)))
+	   (session "*scheme*")
+	   (full-body (org-babel-expand-body:scheme body params))
+	   (comint-use-prompt-regexp nil)
+	   (result
+	    (progn
+	      (print comint-prompt-regexp)
+	      (let* ((out (print (org-babel-comint-with-output
+				     ("*scheme*" "\n> " )
+				   (scheme-send-string (format "(begin %s\n)" body))
+				   (accept-process-output (get-buffer-process (current-buffer))))))
+		     ;; #<unspecifed> etc cannot be read by emacs
+		     ;; also, out is a result of split-string, so we get the car
+		     (blah (print (car out)))
+		     (out (print (s-replace "#" "" (car out))))
+		     (parsed (read out))
+		     (parsed (mapcar (lambda (el)
+				       (xml-escape-string
+					(if (symbolp el)
+					    (symbol-name el)
+					  el))
+				       )
+				     parsed)))
+		(concat
+		 "<div class='eval-result'>\n"
+		 (format "<pre class='res'>%s</pre>\n" (car parsed))
+		 (format "<pre class='out'>%s</pre>\n" (cadr parsed))
+		 (format "<pre class='err'>%s</pre>\n" (caddr parsed))
+		 "</div>"
+		 )
+		;; (print out)
+		;;(s-trim (mapconcat #'identity out "\n"))
+		))))
+      result)))
+   #+END_SRC
+   

--- a/index.org
+++ b/index.org
@@ -1,6 +1,8 @@
-#+PROPERTY: header-args:scheme :exports both :eval never-export
 #+TITLE: s7 playground
 # #+SUBTITLE: Try s7 scheme in your browser
+#+PROPERTY: header-args:scheme :exports both :eval never-export :wrap export html
+# the org-babel-execute:scheme is modded so that it outputs html with the
+# evaluation result, stdout and stderr
 #+OPTIONS: html-style:nil
 #+OPTIONS: toc:nil
 #+OPTIONS: html-postamble:nil
@@ -63,9 +65,6 @@ emrun --serve_after_close index.html
 	 (formatted (format "<div class='code-container'>
 <textarea class='code'>%s</textarea>
 <button class='eval'>eval</button>
-<pre class='res'></pre>
-<pre class='out'></pre>
-<pre class='err'></pre>
 </div>" code)))
     formatted))
 
@@ -108,14 +107,21 @@ This function is called by `org-babel-execute-src-block'"
 	     (full-body (org-babel-expand-body:scheme body params))
 	     (result
 	      (progn
-		(message session)
-		(message full-body)
-		(let ((out (org-babel-comint-with-output
-			       (session ">" t body)
-			     (scheme-send-string body)
-			     (accept-process-output (get-buffer-process (current-buffer))))))
+		(let* ((out (org-babel-comint-with-output
+				(session ">" t body)
+			      (scheme-send-string (format "(begin %s\n)" body))
+			      (accept-process-output (get-buffer-process (current-buffer)))))
+		       (parsed (read out)))
+		  (concat
+		   "<div class='eval-result'>\n"
+		   (format "<pre class='res'>%s</pre>\n" (car parsed))
+		   (format "<pre class='out'>%s</pre>\n" (cadr parsed))
+		   (format "<pre class='err'>%s</pre>\n" (caddr parsed))
+		   "</div>"
+		   )
 		  ;; (print out)
-		  (s-trim (mapconcat #'identity out "\n"))))))
+		  ;;(s-trim (mapconcat #'identity out "\n"))
+		  ))))
 	result))))  
    #+END_SRC
    
@@ -128,14 +134,16 @@ this-will-cause-an-error ;; will cause an error. comment this line and you'll se
 ;; stderr is displayed in red background
   #+END_SRC
 
-  # the .example sibling gets deleted on evaluation
-  #+BEGIN_EXPORT html
-<div class='example'> 
-<pre class='res'>unbound-variable</pre>
-<pre class='out'>Hello there!!</pre>
-<pre class='err'>;unbound variable this-will-cause-an-error in this-will-cause-an-error</pre>
-</div>
-  #+END_EXPORT
+  #+RESULTS:
+  #+BEGIN_export html
+  <div class='eval-result'>
+  <pre class='res'>unbound-variable</pre>
+  <pre class='out'>Hello there!!</pre>
+  <pre class='err'>
+  ;unbound variable this-will-cause-an-error in this-will-cause-an-error
+  </pre>
+  </div>
+  #+END_export
 
 * Math
   s7 includes:
@@ -152,7 +160,22 @@ this-will-cause-an-error ;; will cause an error. comment this line and you'll se
   #+END_SRC
 
   #+RESULTS:
-  : (1 0 94)
+  #+BEGIN_export html
+  <div class='eval-result'>
+  <pre class='res'>(1 0 32)</pre>
+  <pre class='out'></pre>
+  <pre class='err'></pre>
+  </div>
+  #+END_export
+
+
+
+  #+BEGIN_SRC scheme :results value verbatim :exports both
+(list
+ (cos 0)
+ (sin 0)
+ (random 1000))
+  #+END_SRC
 
 * define*, lambda*
   =define*= and =lambda*= are extensions of define and lambda that
@@ -186,7 +209,13 @@ this-will-cause-an-error ;; will cause an error. comment this line and you'll se
   #+END_SRC
 
   #+RESULTS:
-  : ((1 32 "hi") (3 2 "hi") (3 2 1))
+  #+BEGIN_export html
+  <div class='eval-result'>
+  <pre class='res'>((1 32 hi) (3 2 hi) (3 2 1))</pre>
+  <pre class='out'></pre>
+  <pre class='err'></pre>
+  </div>
+  #+END_export
 
 * COMMENT local vars
 

--- a/index.org
+++ b/index.org
@@ -114,7 +114,7 @@ this-will-cause-an-error ;; will cause an error. comment this line and you'll se
   #+RESULTS:
   #+BEGIN_export html
   <div class='eval-result'>
-  <pre class='res'>((1 32 hi) (3 2 hi) (3 2 1))</pre>
+  <pre class='res'>((1 32 &quot;hi&quot;) (3 2 &quot;hi&quot;) (3 2 1))</pre>
   <pre class='out'></pre>
   <pre class='err'></pre>
   </div>

--- a/index.org
+++ b/index.org
@@ -28,103 +28,6 @@
 
 A work-in-progress interactive tutorial of =s7 scheme=. For a more complete manual please refer to https://ccrma.stanford.edu/software/snd/snd/s7.html
 
-* COMMENT dev
-  TODO: move these in =dev.org= file when done with mods.
-  Dev notes: to run the snippets inside emacs.
-
-  #+BEGIN_SRC emacs-lisp :results silent
-;; replace with an s7 repl that handles multi line input properly
-(run-scheme (concat "~/dev/actondev/s7-imgui/build/repl"))
-  #+END_SRC
-
-  #+BEGIN_SRC sh
-source ~/dev/github/emsdk/emsdk_env.sh
-emrun --serve_after_close index.html
-  #+END_SRC
-** org-export-filter-src-block-functions
-   https://orgmode.org/manual/Advanced-Export-Configuration.html
-   Making the src blocks a text input + an eval button
-
-   set =org-html-htmlize-output-type= to nil. that way the =org-export-filter-src-block-functions= will get an "clean" text like
-   #+BEGIN_EXAMPLE
-"<div class=\"org-src-container\">
-<pre class=\"src src-scheme\">(define x 1)
-</pre>
-</div>
-
-"
-   #+END_EXAMPLE
-
-   #+BEGIN_SRC emacs-lisp :results silent
-(defun s7-playground/src-block (text backend info)
-  "Ensure \" \" are properly handled in LaTeX export."
-  (print "src-block info:")
-  (print text)
-  ;; (print info)
-  (let* ((code (s-trim (replace-regexp-in-string "<[^>]*>" "" text)))
-	 (formatted (format "<div class='code-container'>
-<textarea class='code'>%s</textarea>
-<button class='eval'>eval</button>
-</div>" code)))
-    formatted))
-
-;; only eval once
-'(add-to-list 'org-export-filter-src-block-functions
-	      's7-playground/src-block)
-   #+END_SRC
-
-   #+BEGIN_SRC emacs-lisp
-(let ((str "<div class=\"org-src-container\">
-<pre class=\"src src-scheme\">(define x 1)
-</pre>
-</div>
-
-"))
-  (replace-regexp-in-string "<[^>]*>" "" str))
-   #+END_SRC
-
-
-*** Other notes
-    #+BEGIN_QUOTE
-   
-    Oh wait! Just found org-babel-map-src-blocks and the two hooks org-export-before-{processing,parsing}-hook. That's probably what I'm going to do. – purple_arrows Sep 25 '18 at 22:14
-
-    #+END_QUOTE
-
-** org-babel-execute:scheme
-   Redefining =org-babel-execute:scheme= cause it uses geiser.. ugh!
-   #+BEGIN_SRC emacs-lisp :results silent
-(defun org-babel-execute:scheme (body params)
-  "Execute a block of Scheme code with org-babel.
-This function is called by `org-babel-execute-src-block'"
-  (let* ((source-buffer (current-buffer))
-	 (source-buffer-name (replace-regexp-in-string ;; zap surrounding *
-			      "^ ?\\*\\([^*]+\\)\\*" "\\1"
-			      (buffer-name source-buffer))))
-    (save-excursion
-      (let* ((result-type (cdr (assq :result-type params)))
-	     (session "*scheme*")
-	     (full-body (org-babel-expand-body:scheme body params))
-	     (result
-	      (progn
-		(let* ((out (org-babel-comint-with-output
-				(session ">" t body)
-			      (scheme-send-string (format "(begin %s\n)" body))
-			      (accept-process-output (get-buffer-process (current-buffer)))))
-		       (parsed (read out)))
-		  (concat
-		   "<div class='eval-result'>\n"
-		   (format "<pre class='res'>%s</pre>\n" (car parsed))
-		   (format "<pre class='out'>%s</pre>\n" (cadr parsed))
-		   (format "<pre class='err'>%s</pre>\n" (caddr parsed))
-		   "</div>"
-		   )
-		  ;; (print out)
-		  ;;(s-trim (mapconcat #'identity out "\n"))
-		  ))))
-	result))))  
-   #+END_SRC
-   
 * Intro
   #+BEGIN_SRC scheme
 ;; these are some comments
@@ -169,7 +72,7 @@ this-will-cause-an-error ;; will cause an error. comment this line and you'll se
   #+END_export
 
 
-
+  # TODO remove: just showcasing that when we don't already have any results, they get created from javascript
   #+BEGIN_SRC scheme :results value verbatim :exports both
 (list
  (cos 0)
@@ -217,8 +120,51 @@ this-will-cause-an-error ;; will cause an error. comment this line and you'll se
   </div>
   #+END_export
 
-* COMMENT local vars
+* Macros
+  #+BEGIN_SRC scheme
+(define-macro (repl-examples . args)
+  `(for-each (lambda (exp)
+	       (format #t "~A\n;; => ~A\n" exp (eval exp)))
+	     ',args))
 
+(repl-examples
+ (+ 1 2 1)
+ (/ 10 2)
+ )
+  #+END_SRC
+
+  #+RESULTS:
+  #+BEGIN_export html
+  <div class='eval-result'>
+  <pre class='res'>&lt;unspecified&gt;</pre>
+  <pre class='out'>(+ 1 2 1)
+  ;; =&gt; 4
+  (/ 10 2)
+  ;; =&gt; 5
+  </pre>
+  <pre class='err'></pre>
+  </div>
+  #+END_export
+
+
+  #+BEGIN_SRC scheme
+(list 1 2 3)
+  #+END_SRC
+
+  #+RESULTS:
+  #+BEGIN_export html
+  <div class='eval-result'>
+  <pre class='res'>(1 2 3)</pre>
+  <pre class='out'></pre>
+  <pre class='err'></pre>
+  </div>
+  #+END_export
+
+
+
+
+* COMMENT local vars
+  =org-html-htmlize-output-type= also helps with the =*hideshowvis*= problem. (see my blog publishing code as well)
   # Local Variables:
   # org-html-htmlize-output-type: nil
   # End:

--- a/index.org
+++ b/index.org
@@ -65,11 +65,60 @@ this-will-cause-an-error ;; will cause an error. comment this line and you'll se
   #+RESULTS:
   #+BEGIN_export html
   <div class='eval-result'>
-  <pre class='res'>(1 0 32)</pre>
+  <pre class='res'>(1 0 33)</pre>
   <pre class='out'></pre>
   <pre class='err'></pre>
   </div>
   #+END_export
+
+  Other math-related differences between s7 and r5rs:
+  - =rational?= and =exact= mean integer or ratio (i.e. not floating point), inexact means not exact.
+  - =floor=, =ceiling=, =truncate=, and =round= return (exact) integer results.
+  - =#= does not stand for an unknown digit.
+  - the "@" complex number notation is not supported ("@" is an exponent marker in s7).
+  - =+i= is not considered a number; include the real part.
+  - =modulo=, =remainder=, and =quotient= take integer, ratio, or real arguments.
+  - =lcm= and =gcd= can take integer or ratio arguments.
+  - =log= takes an optional second argument, the base.
+  - =.= and an exponent can occur in a number in any base.
+  - =rationalize= returns a ratio!
+  - =case= is significant in numbers, as elsewhere: #b0 is 0, but #B0 is an error. 
+
+  # note: the examples macros is defined later, in the Macros heading
+  #+BEGIN_SRC scheme :exports results :s7-results output :wrap src scheme
+(examples
+ (exact? 1.0)
+ (rational? 1.5)
+ (floor 1.4)
+ (remainder 2.4 1)
+ (modulo 1.4 1.0)
+ (lcm 3/4 1/6)
+ (log 8 2)
+ (number->string 0.5 2)
+ (string->number "0.1" 2)
+ (rationalize 1.5)
+ (complex 1/2 0)
+ (logbit? 6 1) ; argument order, (logbit? int index), follows gmp, not CL
+ )
+  #+END_SRC
+
+  #+RESULTS:
+  #+BEGIN_src scheme
+  (exact? 1.0) ;; => #f
+  (rational? 1.5) ;; => #f
+  (floor 1.4) ;; => 1
+  (remainder 2.4 1) ;; => 0.3999999999999999
+  (modulo 1.4 1.0) ;; => 0.3999999999999999
+  (lcm 3/4 1/6) ;; => 3/2
+  (log 8 2) ;; => 3
+  (number->string 0.5 2) ;; => 0.1
+  (string->number "0.1" 2) ;; => 0.5
+  (rationalize 1.5) ;; => 3/2
+  (complex 1/2 0) ;; => 1/2
+  (logbit? 6 1) ;; => #t
+  #+END_src
+
+
 
 
   # TODO remove: just showcasing that when we don't already have any results, they get created from javascript
@@ -79,6 +128,17 @@ this-will-cause-an-error ;; will cause an error. comment this line and you'll se
  (sin 0)
  (random 1000))
   #+END_SRC
+
+  #+RESULTS:
+  #+BEGIN_export html
+  <div class='eval-result'>
+  <pre class='res'>(1 0 578)</pre>
+  <pre class='out'></pre>
+  <pre class='err'></pre>
+  </div>
+  #+END_export
+
+
 
 * define*, lambda*
   =define*= and =lambda*= are extensions of define and lambda that
@@ -122,12 +182,12 @@ this-will-cause-an-error ;; will cause an error. comment this line and you'll se
 
 * Macros
   #+BEGIN_SRC scheme
-(define-macro (repl-examples . args)
+(define-macro (examples . args)
   `(for-each (lambda (exp)
-	       (format #t "~A\n;; => ~A\n" exp (eval exp)))
+	       (format #t "~A ;; => ~A\n" exp (eval exp)))
 	     ',args))
 
-(repl-examples
+(examples
  (+ 1 2 1)
  (/ 10 2)
  )
@@ -137,10 +197,8 @@ this-will-cause-an-error ;; will cause an error. comment this line and you'll se
   #+BEGIN_export html
   <div class='eval-result'>
   <pre class='res'>&lt;unspecified&gt;</pre>
-  <pre class='out'>(+ 1 2 1)
-  ;; =&gt; 4
-  (/ 10 2)
-  ;; =&gt; 5
+  <pre class='out'>(+ 1 2 1) ;; =&gt; 4
+  (/ 10 2) ;; =&gt; 5
   </pre>
   <pre class='err'></pre>
   </div>

--- a/index.org
+++ b/index.org
@@ -3,12 +3,8 @@
 #+PROPERTY: header-args:scheme :exports both :eval never-export :wrap export html
 # the org-babel-execute:scheme is modded so that it outputs html with the
 # evaluation result, stdout and stderr
-#+OPTIONS: html-style:nil
-#+OPTIONS: toc:nil
-#+OPTIONS: html-postamble:nil
+#+OPTIONS: html-postamble:nil num:nil html-style:nil toc:nil
 # see https://orgmode.org/manual/Publishing-options.html
-#+OPTIONS: num:nil
-
 # -- codemirror
 #+HTML_HEAD: <script type="text/javascript" src="libs/codemirror/lib/codemirror.js"></script>
 #+HTML_HEAD: <link rel="stylesheet" href="libs/codemirror/lib/codemirror.css">
@@ -26,15 +22,23 @@
 #+HTML_HEAD: <script type="text/javascript" src="js/s7-playground.js"></script>
 #+HTML_HEAD: <link rel='stylesheet' type='text/css' href='css/style.css'/>
 
-A work-in-progress interactive tutorial of =s7 scheme=. For a more complete manual please refer to https://ccrma.stanford.edu/software/snd/snd/s7.html
+
+A work-in-progress interactive tutorial of =s7 scheme=. For a complete
+manual please refer to
+https://ccrma.stanford.edu/software/snd/snd/s7.html
+
+# showing the toc after my intro text
+#+TOC: headlines
 
 * Intro
   #+BEGIN_SRC scheme
 ;; these are some comments
-(display "Hello there!!") ;; stdout is displayed with blue background
-(+ 1 2 3) ;; output is displayed in gray background
-this-will-cause-an-error ;; will cause an error. comment this line and you'll see "6" in the output
-;; stderr is displayed in red background
+(display "Hello there!!") ;; stdout is displayed in blue
+(+ 1 2 3)
+;; comment the following line (prepend ";;")  and you'll see 6 as a result
+this-will-cause-an-error
+;; stderr is displayed in red
+;; note: the result you get is the result of the last evaluated expression
   #+END_SRC
 
   #+RESULTS:
@@ -181,7 +185,155 @@ this-will-cause-an-error ;; will cause an error. comment this line and you'll se
   #+END_export
 
 * Macros
+  Macros is where the lisp languages really shine. They can extend the
+  language in ways otherwise not possible. They are also quite tricky to get,
+  personally it took me some time to understand the concept.
+  
+  My short explanation that I wish I had read somewhere else:
+  - When you call a normal function =(my-function (+ 1 2))=, the
+    argument =(+ 1 2)= gets evaluated and its result gets passed to
+    the function. So, in the function body, that argument already has the value =3=
+  - On the contrary, when you call a macro, the macro accepts exactly
+    what you have typed. Meaning, upon calling =(my-macro (+ 1 2))=,
+    the argument inside the macro is the exact list you typed, meaning
+    =(+ 1 2)= and *not* =3= which is the result you'd get after
+    evaluation. So, in other words, you have to evaluate the arguments
+    inside the macro yourself to get their value.
+
+  Demonstrating this in code:
   #+BEGIN_SRC scheme
+(define (my-function x)
+  (format #t "my-function: x is ~A\n" x)
+  x)
+
+(define-macro (my-macro x)
+  (format #t "my-macro: x is ~A\n" x)
+  ;; macros need to return some list ` is just a handy construct
+  `',x ;; the `',x causes to return the argument as passed: a list
+  )
+
+(my-function (+ 1 2))
+(my-macro (+ 1 2))
+  #+END_SRC
+
+  #+RESULTS:
+  #+BEGIN_export html
+  <div class='eval-result'>
+  <pre class='res'>(+ 1 2)</pre>
+  <pre class='out'>my-function: x is 3
+  my-macro: x is (+ 1 2)
+  </pre>
+  <pre class='err'></pre>
+  </div>
+  #+END_export
+
+
+  An example with =if=. Let's say =if= wasn't available in the
+  language, and we will construct =my-if=. We want to pass 3 arguments
+  to =my-if=
+  - First, will be the test clause.
+  - Then will be our 2 branches.
+
+  If the test clause is =not false=, we shall execute (aka =evaluate=)
+  the 1st branch (aka 2nd argument), otherwise the 2nd branch (aka 3rd argument).
+
+  To summarize, the signature shall be =(my-if test-clause branch-true branch-false)=.
+
+  - Q: Could we implement it as a function?
+  - A: No! As we said above, when we call a function, all its arguments are evaluated. Let me demonstrate:
+
+  #+BEGIN_SRC scheme
+(define (my-if-function test-clause branch-true branch-false)
+  ;; yeah yeah, we use here the normal if but..
+  ;; cannot do this in another way!
+  (if test-clause branch-true branch-false))
+
+(my-if-function
+ #f ;; let's run the 2nd one
+ (begin
+   (display "executing branch-true\n")
+   1)
+ (begin
+   (display "executing branch-false\n")
+   2))
+  #+END_SRC
+
+  #+RESULTS:
+  #+BEGIN_export html
+  <div class='eval-result'>
+  <pre class='res'>2</pre>
+  <pre class='out'>executing branch-true
+  executing branch-false
+  </pre>
+  <pre class='err'></pre>
+  </div>
+  #+END_export
+
+  You see? But in our =my-if= we don't want the branch-true to be evaluated if not necessary! That's why we need a macro.
+
+  #+BEGIN_SRC scheme
+(define-macro (my-if-macro test-clause branch-true branch-false)
+  `(if ,test-clause
+       ,branch-true
+       ,branch-false))
+
+(my-if-macro
+ #f ;; let's run the 2nd one
+ (begin
+   (display "executing branch-true\n")
+   1)
+ (begin
+   (display "executing branch-false\n")
+   2))
+  #+END_SRC
+
+  #+RESULTS:
+  #+BEGIN_export html
+  <div class='eval-result'>
+  <pre class='res'>2</pre>
+  <pre class='out'>executing branch-false
+  </pre>
+  <pre class='err'></pre>
+  </div>
+  #+END_export
+
+  You see the difference? Before we go on explaining how you write a macro, let me show you a different Implementation of =my-if=
+  #+BEGIN_SRC scheme
+(define-macro (my-if-macro2 test-clause branch-true branch-false)
+  (if (eval test-clause)
+      (eval branch-true)
+      (eval branch-false)))
+
+(my-if-macro2
+ #f ;; let's run the 2nd one
+ (begin
+   (display "executing branch-true\n")
+   1)
+ (begin
+   (display "executing branch-false\n")
+   2))
+  #+END_SRC
+
+  #+RESULTS:
+  #+BEGIN_export html
+  <div class='eval-result'>
+  <pre class='res'>2</pre>
+  <pre class='out'>executing branch-false
+  </pre>
+  <pre class='err'></pre>
+  </div>
+  #+END_export
+
+  These 2 implentations are essentially the same.
+
+
+** Fun with macros
+   Internally in this document I'm using the =examples= macro to
+   showcase small snippets and their results. That saves me from
+   writing the result myself. I only write the code snippets wrapped
+   around the =examples= macro call, and evaluate it to get the =<code
+   snippet> ;; => <result>= output
+   #+BEGIN_SRC scheme
 (define-macro (examples . args)
   `(for-each (lambda (exp)
 	       (format #t "~A ;; => ~A\n" exp (eval exp)))
@@ -191,33 +343,18 @@ this-will-cause-an-error ;; will cause an error. comment this line and you'll se
  (+ 1 2 1)
  (/ 10 2)
  )
-  #+END_SRC
+   #+END_SRC
 
-  #+RESULTS:
-  #+BEGIN_export html
-  <div class='eval-result'>
-  <pre class='res'>&lt;unspecified&gt;</pre>
-  <pre class='out'>(+ 1 2 1) ;; =&gt; 4
-  (/ 10 2) ;; =&gt; 5
-  </pre>
-  <pre class='err'></pre>
-  </div>
-  #+END_export
-
-
-  #+BEGIN_SRC scheme
-(list 1 2 3)
-  #+END_SRC
-
-  #+RESULTS:
-  #+BEGIN_export html
-  <div class='eval-result'>
-  <pre class='res'>(1 2 3)</pre>
-  <pre class='out'></pre>
-  <pre class='err'></pre>
-  </div>
-  #+END_export
-
+   #+RESULTS:
+   #+BEGIN_export html
+   <div class='eval-result'>
+   <pre class='res'>&lt;unspecified&gt;</pre>
+   <pre class='out'>(+ 1 2 1) ;; =&gt; 4
+   (/ 10 2) ;; =&gt; 5
+   </pre>
+   <pre class='err'></pre>
+   </div>
+   #+END_export
 
 
 

--- a/js/s7-playground.js
+++ b/js/s7-playground.js
@@ -1,3 +1,13 @@
+function escapeHtml(unsafe) {
+    // https://stackoverflow.com/a/6234804
+    return unsafe
+         .replace(/&/g, "&amp;")
+         .replace(/</g, "&lt;")
+         .replace(/>/g, "&gt;")
+         .replace(/"/g, "&quot;")
+         .replace(/'/g, "&#039;");
+ }
+
 function createPreWithClass(className){
     const el = document.createElement("pre");
     el.className = className;
@@ -64,9 +74,9 @@ function setup() {
 		parent.parentNode.insertBefore(evalResult, parent.nextSibling);
 	    }
 
-	    evalResult.querySelector('.res').innerHTML = res;
-	    evalResult.querySelector('.out').innerHTML = out;
-	    evalResult.querySelector('.err').innerHTML = err;
+	    evalResult.querySelector('.res').innerHTML = escapeHtml(res);
+	    evalResult.querySelector('.out').innerHTML = escapeHtml(out);
+	    evalResult.querySelector('.err').innerHTML = escapeHtml(err);
 	}
     }
 }

--- a/js/s7-playground.js
+++ b/js/s7-playground.js
@@ -1,3 +1,9 @@
+function createPreWithClass(className){
+    const el = document.createElement("pre");
+    el.className = className;
+    return el;
+}
+
 function setup() {
     const codeElements = document.getElementsByClassName("code");
     // looping in reverse. if not, replacing the code elements with codemirror will not work
@@ -36,19 +42,31 @@ function setup() {
 			 [], // argument types
 				     []); // arguments
 
-	    console.log("res:", res);
-	    console.log("out:", out);
-	    console.log("err:", err);
-	    parent.querySelector('.res').innerHTML = res;
-	    parent.querySelector('.out').innerHTML = out;
-	    parent.querySelector('.err').innerHTML = err;
+	    // the document *might* have a div with class eval-result
+	    // which is when manually running the code with the apropriate parsing
+	    // (even all the blocks could be evaluated already!)
+	    // so, in case it exists we just replace with res, out, err
+	    // if not, we create this block
+	    let evalResult = parent.nextSibling;
+	    if(evalResult.className != "eval-result") {
+		evalResult = document.createElement("div");
+		evalResult.className = "eval-result";
 
-	    console.log("parent", parent);
-	    const possibleStaticResult = parent.nextSibling;
-	    if(possibleStaticResult.className == "example") {
-		possibleStaticResult.remove();
+		const elRes = createPreWithClass('res');
+		const elOut = createPreWithClass('out');
+		const elErr = createPreWithClass('err');
+
+		evalResult.appendChild(elRes);
+		evalResult.appendChild(elOut);
+		evalResult.appendChild(elErr);
+
+		// appending evalResult next to our code
+		parent.parentNode.insertBefore(evalResult, parent.nextSibling);
 	    }
-	    // note: check for <empty string> ?
+
+	    evalResult.querySelector('.res').innerHTML = res;
+	    evalResult.querySelector('.out').innerHTML = out;
+	    evalResult.querySelector('.err').innerHTML = err;
 	}
     }
 }

--- a/js/s7-playground.js
+++ b/js/s7-playground.js
@@ -57,7 +57,7 @@ function setup() {
 	    // (even all the blocks could be evaluated already!)
 	    // so, in case it exists we just replace with res, out, err
 	    // if not, we create this block
-	    let evalResult = parent.nextSibling;
+	    let evalResult = parent.nextElementSibling;
 	    if(evalResult.className != "eval-result") {
 		evalResult = document.createElement("div");
 		evalResult.className = "eval-result";
@@ -71,7 +71,7 @@ function setup() {
 		evalResult.appendChild(elErr);
 
 		// appending evalResult next to our code
-		parent.parentNode.insertBefore(evalResult, parent.nextSibling);
+		parent.parentNode.insertBefore(evalResult, parent.nextElementSibling);
 	    }
 
 	    evalResult.querySelector('.res').innerHTML = escapeHtml(res);

--- a/meson.build
+++ b/meson.build
@@ -5,23 +5,30 @@ project('s7-playground', 'c',
 s7 = subproject('s7')
 s7_dep = s7.get_variable('s7_dep')
 
-sources = files(
-  'src/s7_wasm.c',
-  )
-
-#   Note:
-#     Options can be specified as a single argument without a space
-#    between the "-s" and option name.  e.g. "-sFOO=1".
-
-executable('s7_wasm',
-	   sources,
-	   dependencies: [s7_dep],
-	   c_args: [
-	     # note: this is called when compiling the c files to object files
-	   ],
-	   link_args: [
-	     # this is the second pass, emcc -o s7_wasm.js ...
-	     '-sEXTRA_EXPORTED_RUNTIME_METHODS=["ccall"]',
-	     '-sEXPORTED_FUNCTIONS=["_main", "_eval_string", "_get_out", "_get_err"]',
+if meson.is_cross_build()
+  # building for wasm
+  
+  # Note:
+  # Options can be specified as a single argument without a space
+  # between the "-s" and option name.  e.g. "-sFOO=1".
+  executable('s7_wasm',
+	     # sources,
+	     'src/s7_wasm.c',
+	     dependencies: [s7_dep],
+	     c_args: [
+	       # note: this is called when compiling the c files to object files
 	     ],
-	   name_suffix: 'js')
+	     link_args: [
+	       # this is the second pass, emcc -o s7_wasm.js ...
+	       '-sEXTRA_EXPORTED_RUNTIME_METHODS=["ccall"]',
+	       '-sEXPORTED_FUNCTIONS=["_main", "_eval_string", "_get_out", "_get_err"]',
+	     ],
+	     name_suffix: 'js')
+endif
+
+if not meson.is_cross_build()
+  executable('repl',
+	     'src/repl.c',
+	     dependencies: s7_dep,
+	    )
+endif

--- a/readme.org
+++ b/readme.org
@@ -1,6 +1,8 @@
 * s7 playground
   Interactive =s7 scheme= tutorial in your browser.
 
+  https://actondev.github.io/s7-playground/
+
   See
   - [[file:dev.org]] for development info.
   - [[file:index.org]] for the tutorial content

--- a/src/repl.c
+++ b/src/repl.c
@@ -1,0 +1,81 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include "s7.h"
+
+/**
+ * A special REPL that (upon complete input forms) prints out a scheme list:
+ * (result output error)
+ * 
+ * This is to be parsed from emacs and fill out the s7 document results
+ */
+int main(int argc, char** argv)
+{
+    s7_scheme* sc;
+#define BUFFER_SIZE 1024
+    char buffer[BUFFER_SIZE];
+    buffer[0] = '\0';
+    printf("s7-playground repl\n> ");
+
+    sc = s7_init();                 /* initialize the interpreter */
+    s7_pointer out,err;
+    out = err = s7_nil(sc);
+    s7_pointer read_error_symbol = s7_make_symbol(sc, "read-error");
+    do                       /* fire up a read-eval-print loop */
+    {
+        int len = strlen(buffer);
+        fgets(buffer+len, BUFFER_SIZE-len, stdin);
+
+        s7_pointer port = s7_open_input_string(sc, buffer);
+
+        s7_close_output_port(sc, out);
+        s7_close_output_port(sc, err);
+
+        // stdout
+        out = s7_open_output_string(sc);
+        s7_set_current_output_port(sc, out);
+
+        err = s7_open_output_string(sc);
+        s7_set_current_error_port(sc, err);
+
+        s7_pointer form = s7_read(sc, port);
+
+        if (s7_is_equivalent(sc, form, read_error_symbol)) {
+            // read-error
+
+        } else {
+            // eval
+
+            // seems to be ok
+            s7_close_output_port(sc, out);
+            s7_close_output_port(sc, err);
+
+            // stdout
+            out = s7_open_output_string(sc);
+            s7_set_current_output_port(sc, out);
+
+            err = s7_open_output_string(sc);
+            s7_set_current_error_port(sc, err);
+
+            s7_pointer result = s7_eval_c_string(sc, buffer);
+
+            s7_pointer result_list = s7_list(sc, 3,
+                                             result,
+                                             s7_make_string(sc, s7_get_output_string(sc, out)),
+                                             s7_make_string(sc, s7_get_output_string(sc, err))
+                                            );
+
+            char* result_list_str = s7_object_to_c_string(sc, result_list);
+            printf("%s\n> ", result_list_str);
+
+            free(result_list_str);
+            // cleanup buffer
+            buffer[0] = '\0';
+        }
+
+
+    } while(true);
+    
+    // todo s7_free
+    // gotta update s7 version
+}

--- a/src/s7_wasm.c
+++ b/src/s7_wasm.c
@@ -4,16 +4,21 @@
 
 s7_scheme* g_sc = NULL;
 s7_pointer g_out, g_err;
+char* g_out_str = NULL;
 
 int main() {
-    printf("hello, world!\n");
-    g_sc = s7_init();
+     g_sc = s7_init();
+     g_out, g_err = s7_nil(sc);
 
-    return 0;
+     return 0;
 }
 
 // exported to wasm
 const char* eval_string(char* str) {
+     // freeing previous string returned from s7
+     // either like this, or I should copy everytime in my own global and free
+     free(g_out_str);
+
      // closing.. without having opened?
      // seems to be ok
      s7_close_output_port(g_sc, g_out);
@@ -28,13 +33,14 @@ const char* eval_string(char* str) {
      s7_set_current_error_port(g_sc, g_err);
 
      s7_pointer result = s7_eval_c_string(g_sc, str);
-     return s7_object_to_c_string(g_sc, result);
+     g_out_str = s7_object_to_c_string(g_sc, result);
+     return g_out_str;
 }
 
-const char* get_out(){
+const char* get_out() {
      return s7_get_output_string(g_sc, s7_current_output_port(g_sc));
 }
 
-const char* get_err(){
+const char* get_err() {
      return s7_get_output_string(g_sc, s7_current_error_port(g_sc));
 }


### PR DESCRIPTION
added `src/repl.c` which returns a scheme list `(result stdout stderr)`.

I'm using this repl in emacs alongside `cmuscheme` to evaluate code blocks in emacs and calculate their results inside the `index.org` document. The evaluated output gets put into separate `pre` blocks (with classes `.res` `.out` `.err`)

..plus some content & styling